### PR TITLE
fix(l10n): prefer translations from moment.js

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,6 +2,7 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: lib/index.ts:22
+#: lib/index.ts:16
+#: lib/index.ts:19
 msgid "seconds"
 msgstr ""

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,17 +11,14 @@ LOCALES.map(data => {
 gt.setLocale(locale)
 moment.locale(locale)
 
-moment.updateLocale(
-    moment.locale(),
-    {
-        parentLocale: moment.locale(),
-        relativeTime: Object.assign(
-            // @ts-ignore
-            moment.localeData(moment.locale())._relativeTime,
-            {
-                s: gt.gettext('seconds'),
-            }
-        )
+// Only update the seconds translation if it's available. Moment.js ships more locales than we
+// track in transifex, so we prefer the original translation. Always use the english translations.
+if (locale.startsWith('en') || gt.gettext('seconds') !== 'seconds') {
+    moment.updateLocale(moment.locale(), {
+        relativeTime: {
+            s: gt.gettext('seconds'),
+        },
     })
+}
 
 export default moment


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/3657

| Before | After |
| --- | --- |
| ![grafik](https://github.com/nextcloud-libraries/nextcloud-moment/assets/1479486/1274abcf-4505-44c8-a5ec-0723924f735e) | ![grafik](https://github.com/nextcloud-libraries/nextcloud-moment/assets/1479486/713b2f54-d7f7-48b4-85e1-83620d11f05f) |

Moment.js offers more locales than we do via transifex. This leads to some cases (e.g. `German (Austria)`) where the seconds message is not localized but still applied to `moment.js`, even if there is a better translation available inside `moment.js`.
