### PR TITLE
chore: Prepare new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.3.0 - 2024-01-10
+### Enhancements
+* enh: Move package to vite for bundling + compress translations [#781](https://github.com/nextcloud-libraries/nextcloud-moment/pull/781) \([susnux](https://github.com/susnux)\)
+
+### Changed
+* chore(package): replace .npmignore with files array [#757](https://github.com/nextcloud-libraries/nextcloud-moment/pull/757) \([st3iny](https://github.com/st3iny)\)
+* chore: Update workflows [#780](https://github.com/nextcloud-libraries/nextcloud-moment/pull/780) \([susnux](https://github.com/susnux)\)
+* fix: Adjust readme as we no longer use travis [#794](https://github.com/nextcloud-libraries/nextcloud-moment/pull/794) \([susnux](https://github.com/susnux)\)
+* Update dependencies
+* Update translations
+
 ## 1.2.2 – 2023-10-17
 ### Changed
 - Dependency updates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/moment",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/moment",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/l10n": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nextcloud/moment",
-  "version": "1.2.2",
-  "description": "",
+  "version": "1.3.0",
+  "description": "Customized moment.js for Nextcloud",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Not sure if we consider this breaking and so need 2.0.0? Or Just 1.3.0?

---

## 1.3.0- 2024-01-10
### Enhancements
* enh: Move package to vite for bundling + compress translations [#781](https://github.com/nextcloud-libraries/nextcloud-moment/pull/781) \([susnux](https://github.com/susnux)\)

### Changed
* chore(package): replace .npmignore with files array [#757](https://github.com/nextcloud-libraries/nextcloud-moment/pull/757) \([st3iny](https://github.com/st3iny)\)
* chore: Update workflows [#780](https://github.com/nextcloud-libraries/nextcloud-moment/pull/780) \([susnux](https://github.com/susnux)\)
* fix: Adjust readme as we no longer use travis [#794](https://github.com/nextcloud-libraries/nextcloud-moment/pull/794) \([susnux](https://github.com/susnux)\)
* Update dependencies
* Update translations