### PR TITLE
fix: Add explicit file extension to fix module resolution with Webpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.3.1 - 2024-01-10
+### Fixed
+* Fixed module resolution when using webpack + babel
+
 ## 1.3.0 - 2024-01-10
 ### Enhancements
 * enh: Move package to vite for bundling + compress translations [#781](https://github.com/nextcloud-libraries/nextcloud-moment/pull/781) \([susnux](https://github.com/susnux)\)

--- a/lib/constants.d.ts
+++ b/lib/constants.d.ts
@@ -4,3 +4,8 @@ interface Translations {
 }
 
 declare const LOCALES: Translations[]
+
+declare module 'moment/min/moment-with-locales.js' {
+	import moment from 'moment'
+	export default moment
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-import moment from 'moment/min/moment-with-locales'
+import moment from 'moment/min/moment-with-locales.js'
 import Gettext from 'node-gettext'
 import { getLocale } from '@nextcloud/l10n'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/moment",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/moment",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/l10n": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/moment",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Customized moment.js for Nextcloud",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
In some circumstances Webpack fails to resolve the module, this breaks e.g. forms 3.x.

So we need the explicit file extension to fix it.