### PR TITLE
chore: Prepare v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.3.2 - 2024-04-21
+### Changed
+* Update NPM version to LTS 10 [#863](https://github.com/nextcloud-libraries/nextcloud-moment/pull/863) \([susnux](https://github.com/susnux)\)
+* Updated development dependencies
+
 ## 1.3.1 - 2024-01-10
 ### Fixed
 * Fixed module resolution when using webpack + babel

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/moment",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/moment",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/l10n": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/moment",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Customized moment.js for Nextcloud",
   "main": "dist/index.cjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## 1.3.2 - 2024-04-21
### Changed
* Update NPM version to LTS 10 [#863](https://github.com/nextcloud-libraries/nextcloud-moment/pull/863) \([susnux](https://github.com/susnux)\)
* Updated development dependencies