### PR TITLE
fix(deps): migrate away from node-gettext

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,6 +2,6 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
-#: lib/index.ts:24
+#: lib/index.ts:25
 msgid "seconds"
 msgstr ""

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 import moment from 'moment/min/moment-with-locales.js'
-import Gettext from 'node-gettext'
 import { getLocale } from '@nextcloud/l10n'
+import { getGettextBuilder } from '@nextcloud/l10n/gettext'
 
 const locale = getLocale()
 const translations = LOCALES
@@ -15,9 +15,10 @@ moment.locale(locale)
 // track in transifex, so we prefer the included translation. Always prefer our default english
 // translation.
 if (locale === 'en' || locale in translations) {
-	const gt = new Gettext()
-	gt.addTranslations(locale, 'messages', translations[locale])
-	gt.setLocale(locale)
+	const gt = getGettextBuilder()
+		.setLanguage(locale)
+		.addTranslation(locale, translations[locale])
+		.build()
 
 	moment.updateLocale(moment.locale(), {
 		relativeTime: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/l10n": "^3.1.0",
+        "@nextcloud/l10n": "^3.2.0",
         "moment": "^2.30.1",
         "node-gettext": "^3.0.0"
       },
@@ -18,7 +18,6 @@
         "@nextcloud/eslint-config": "^8.3.0",
         "@nextcloud/vite-config": "^2.2.2",
         "@types/node": "^22.7.5",
-        "@types/node-gettext": "^3.0.6",
         "eslint": "^8.56.0",
         "gettext-extractor": "^3.8.0",
         "gettext-parser": "^8.0.0",
@@ -2042,12 +2041,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/node-gettext": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/node-gettext/-/node-gettext-3.0.6.tgz",
-      "integrity": "sha512-A0W1IyyW3Ya+Wj6fDDWWwnXWNgrDNvKkq6xKj5Korc7YIo9023LP8qVTzgwQ5SUIANg2Pm2ggA7bfTcwoPPDUQ==",
-      "dev": true
     },
     "node_modules/@types/parse5": {
       "version": "5.0.3",
@@ -5309,6 +5302,7 @@
       "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-8.0.0.tgz",
       "integrity": "sha512-eFmhDi2xQ+2reMRY2AbJ2oa10uFOl1oyGbAKdCZiNOk94NJHi7aN0OBELSC9v35ZAPQdr+uRBi93/Gu4SlBdrA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
         "encoding": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dist"
   ],
   "dependencies": {
-    "@nextcloud/l10n": "^3.1.0",
+    "@nextcloud/l10n": "^3.2.0",
     "moment": "^2.30.1",
     "node-gettext": "^3.0.0"
   },
@@ -48,7 +48,6 @@
     "@nextcloud/eslint-config": "^8.3.0",
     "@nextcloud/vite-config": "^2.2.2",
     "@types/node": "^22.7.5",
-    "@types/node-gettext": "^3.0.6",
     "eslint": "^8.56.0",
     "gettext-extractor": "^3.8.0",
     "gettext-parser": "^8.0.0",


### PR DESCRIPTION
This follows the lead of https://github.com/nextcloud-libraries/nextcloud-l10n/pull/851/ and replaces node-gettext calls with the l10n package's new internal handling.

This makes it possible to get rid of the vulnerable node-gettext package in apps.